### PR TITLE
Build on all Ruby versions we support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     name: Run rspec
     permissions: write-all
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version:
+          - '3.2'
+          - '3.3'
+          - '3.4'
 
     steps:
     - name: Checkout code
@@ -15,7 +22,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.2'
+        ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
     - name: Run tests
@@ -42,7 +49,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2'
+          ruby-version: '3.3'
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
       - name: Run RuboCop


### PR DESCRIPTION
We currently have services on both 3.2 and 3.3, and we're likely going to upgrade to 3.4 soon, so testing on it is a good idea.